### PR TITLE
Provides configurability of asciidoc toclevel attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ time and can be previewed using the Chrome _Asciidoctor.js_ plugin.
 
 Documentation can be generated with `mvn asciidoctor:process-asciidoc` or `mvn asciidoctor:auto-refresh`, the _Asciidoc_ files are transformed to HTML the _target/docs_ directory.
 
+By default, the generated HTML uses a left TOC with 2 levels show, you can override the number of levels shown with the `vertx.asciidoc.attributes.toclevels` property: `mvn asciidoctor:process-asciidoc -Dvertx.asciidoc.attributes.toclevels=5`
+
 This documentation shall be packaged in a `-docs.zip` file.
 
 ```xml
@@ -91,4 +93,3 @@ This documentation shall be packaged in a `-docs.zip` file.
     </plugin>
   </build>
 ```
-

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
     <!-- Asciidoc -->
     <vertx.asciidoc.sources.dir>${project.basedir}/src/main/asciidoc</vertx.asciidoc.sources.dir>
     <vertx.asciidoc.target.dir>${project.build.directory}/asciidoc/java</vertx.asciidoc.target.dir>
+    <vertx.asciidoc.attributes.toclevels>2</vertx.asciidoc.attributes.toclevels>
 
     <!-- Codegen -->
     <vertx.generated.sources.dir>${project.basedir}/src/main/generated</vertx.generated.sources.dir>
@@ -238,6 +239,7 @@
             <doctype>book</doctype>
             <attributes>
               <toc>left</toc>
+              <toclevels>${vertx.asciidoc.attributes.toclevels}</toclevels>
               <source-highlighter>coderay</source-highlighter>
               <icons>font</icons>
             </attributes>


### PR DESCRIPTION
Motivation:

Sometimes for visualisation purpose, we would like to have more than 2 levels of TOC shown.

Changes:

Add a maven property that defines the number of toclevel and passes it to the asciidoctor plugin.
